### PR TITLE
ビューの編集

### DIFF
--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -1,4 +1,4 @@
-html, body {
+.whole-page{
   height: 100%;
   width: 100%;
   margin: 0px;
@@ -9,12 +9,11 @@ html, body {
     height: 100%;
     width: 300px;
     float: left;
-    overflow: scroll;
 
     .user {
       background-color: $UserBlue;
       height: 96px;
-      width: 100%;
+      width: inherit;
 
         .user-info{
           width: 260px;
@@ -64,34 +63,34 @@ html, body {
           }
         }
     }
-    .groups{
-      background-color: $DarkBlue;
-      padding-bottom: 80px;
-      .group-list{
-        width: 260px;
-        list-style-type: none;
-        margin: 0 auto;
-        padding-top: 20px;
-        display: block;
-        &__group-name p{
-          font-size: 15px;
-          color: White;
+        .groups {
+          background-color: $DarkBlue;
+          padding-bottom: 122px;
+          overflow: scroll;
+          height: 100vh;
+          a{
+            text-decoration: none;
+            .group-list{
+              width: 260px;
+              list-style-type: none;
+              margin: 0 auto;
+              padding-top: 20px;
+              display: block;
+              text-decoration: none;
+              &__group-name p{
+                font-size: 15px;
+                color: White;
+                text-decoration: none;
+              }
+              &__group-news p{
+                font-size: 12px;
+                color: White;
+                margin-top: 5px;
+                padding-bottom: 40px
+              }
+            }
+          }
         }
-        &__group-news p{
-          font-size: 12px;
-          color: White;
-          margin-top: 5px;
-          padding-bottom: 40px
-        }
-      }
-    }
-    .fix-blank{
-      position: fixed;
-      width:inherit;
-      bottom: 0;
-      height: 90px;
-      background-color: $DarkBlue;
-    }
   }
 
   .chat-show{
@@ -99,7 +98,6 @@ html, body {
     height: 100%;
     width: calc(100vw - 300px);
     float: left;
-    overflow: scroll;
 
     .chat-show-group{
       height: 96px;
@@ -156,6 +154,8 @@ html, body {
       background-color: $White;
       margin-top: 122px;
       padding-bottom: 80px;
+      overflow: scroll;
+      height: 100vh;
       &__content{
         margin-left: 40px;
         padding-bottom: 40px;

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -72,7 +72,7 @@ html, body {
         list-style-type: none;
         margin: 0 auto;
         padding-top: 20px;
-
+        display: block;
         &__group-name p{
           font-size: 15px;
           color: White;

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -76,7 +76,6 @@
               margin: 0 auto;
               padding-top: 20px;
               display: block;
-              text-decoration: none;
               &__group-name p{
                 font-size: 15px;
                 color: White;
@@ -94,7 +93,6 @@
   }
 
   .chat-show{
-    /*background-color: $ChatBackGround;*/
     height: 100%;
     width: calc(100vw - 300px);
     float: left;
@@ -149,7 +147,6 @@
       }
     }
     .chat-list{
-      /*height: calc(100% - 142px);*/
       width: 100%;
       background-color: $White;
       margin-top: 122px;

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -9,6 +9,7 @@ html, body {
     height: 100%;
     width: 300px;
     float: left;
+    overflow: scroll;
 
     .user {
       background-color: $UserBlue;
@@ -63,30 +64,42 @@ html, body {
           }
         }
     }
-    .group-list{
-      width: 260px;
-      list-style-type: none;
-      margin: 0 auto;
-      padding-top: 20px;
+    .groups{
+      background-color: $DarkBlue;
+      padding-bottom: 80px;
+      .group-list{
+        width: 260px;
+        list-style-type: none;
+        margin: 0 auto;
+        padding-top: 20px;
 
-      &__group-name p{
-        font-size: 15px;
-        color: White;
+        &__group-name p{
+          font-size: 15px;
+          color: White;
+        }
+        &__group-news p{
+          font-size: 12px;
+          color: White;
+          margin-top: 5px;
+          padding-bottom: 40px
+        }
       }
-      &__group-news p{
-        font-size: 12px;
-        color: White;
-        margin-top: 5px;
-        padding-bottom: 40px
-      }
+    }
+    .fix-blank{
+      position: fixed;
+      width:inherit;
+      bottom: 0;
+      height: 90px;
+      background-color: $DarkBlue;
     }
   }
 
   .chat-show{
-    background-color: $ChatBackGround;
+    /*background-color: $ChatBackGround;*/
     height: 100%;
     width: calc(100vw - 300px);
     float: left;
+    overflow: scroll;
 
     .chat-show-group{
       height: 96px;
@@ -138,10 +151,11 @@ html, body {
       }
     }
     .chat-list{
-      height: calc(100% - 142px);
+      /*height: calc(100% - 142px);*/
       width: 100%;
       background-color: $White;
-      padding-top: 142px;
+      margin-top: 122px;
+      padding-bottom: 80px;
       &__content{
         margin-left: 40px;
         padding-bottom: 40px;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,6 +3,7 @@ class MessagesController < ApplicationController
   before_action :set_group
   def index
     @message = Message.new
+    @messages = @group.messages
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,6 +7,7 @@ class MessagesController < ApplicationController
   end
 
   def create
+    @messages = @group.messages
     @message = @group.messages.new(message_params)
     if @message.save
       flash[:notice] = "送信成功"

--- a/app/views/groups/_group.html.haml
+++ b/app/views/groups/_group.html.haml
@@ -1,6 +1,10 @@
 -groups.each do |group|
-  %ul.group-list
-    %li.group-list__group-name
-      %p #{group.group_name}
-    %li.group-list__group-news
-      %p まだ新着メッセージはありません。
+  =link_to group_messages_path(group.id) do
+    %ul.group-list
+      %li.group-list__group-name
+        %p #{group.group_name}
+      %li.group-list__group-news
+        -if group.messages.last.present?
+          %p #{group.messages.last.body}
+        -else
+          %p まだメッセージはありません。

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,4 +1,4 @@
-%body
+.whole-page
   .side-bar
     .user
       %ul.user-info

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,5 +7,5 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'true'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'true'
   %body
-    =render 'layouts/notification'
+    = render 'layouts/notification'
     = yield

--- a/app/views/messages/_chat-list.html.haml
+++ b/app/views/messages/_chat-list.html.haml
@@ -1,4 +1,5 @@
-%ul.chat-list__content
-  %li.member-name tarou
-  %li.chat-date 2017/09/05 07:54:06
-  %li.chat-text なるほど
+-messages.each do |message|
+  %ul.chat-list__content
+    %li.member-name #{message.user.name}
+    %li.chat-date #{message.created_at}
+    %li.chat-text #{message.body}

--- a/app/views/messages/_chat-list.html.haml
+++ b/app/views/messages/_chat-list.html.haml
@@ -3,3 +3,6 @@
     %li.member-name #{message.user.name}
     %li.chat-date #{message.created_at}
     %li.chat-text #{message.body}
+    -if message.image.present?
+      %li.chat-image
+        =image_tag message.image.thumb.url

--- a/app/views/messages/_group.html.haml
+++ b/app/views/messages/_group.html.haml
@@ -3,4 +3,7 @@
     %li.group-list__group-name
       %p #{group.group_name}
     %li.group-list__group-news
-      %p まだ新着メッセージはありません。
+      -if group.messages.last.present?
+        %p #{group.messages.last.body}
+      -else
+        %p 最新のメッセージはありません。

--- a/app/views/messages/_group.html.haml
+++ b/app/views/messages/_group.html.haml
@@ -1,9 +1,10 @@
 -groups.each do |group|
-  %ul.group-list
-    %li.group-list__group-name
-      %p #{group.group_name}
-    %li.group-list__group-news
-      -if group.messages.last.present?
-        %p #{group.messages.last.body}
-      -else
-        %p 最新のメッセージはありません。
+  =link_to group_messages_path(group.id) do
+    %ul.group-list
+      %li.group-list__group-name
+        %p #{group.group_name}
+      %li.group-list__group-news
+        -if group.messages.last.present?
+          %p #{group.messages.last.body}
+        -else
+          %p まだメッセージはありません。

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -26,7 +26,7 @@
       %button
         %p Edit
     .chat-list
-      =render :partial => 'chat-list'
+      =render :partial => 'chat-list', locals: {messages: @messages}
     .chat-form
       =form_for [@group, @message] do |f|
         =f.text_field :body, placeholder: "type a message", rows: 1, cols: 30, class: "withicon"

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,4 +1,4 @@
-%body
+.whole-page
   .side-bar
     .user
       %ul.user-info
@@ -14,7 +14,6 @@
 
     .groups
       =render partial: 'group', locals: {groups: current_user.groups}
-    .fix-blank
 
   .chat-show
     .chat-show-group

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -20,12 +20,13 @@
     .chat-show-group
       %ul.chat-show-group__name
         %li.name
-          %p sampleグループ
+          %p #{@group.group_name}
         %li.members
-          %p Members: tarou, jirou
+          %p Members: #{@group.users.map(&:name).join(',')}
     .edit-button
-      %button
-        %p Edit
+      =link_to edit_group_path(@group.id) do
+        %button
+          %p Edit
     .chat-list
       =render :partial => 'chat-list', locals: {messages: @messages}
     .chat-form

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -14,6 +14,7 @@
 
     .groups
       =render partial: 'group', locals: {groups: current_user.groups}
+    .fix-blank
 
   .chat-show
     .chat-show-group

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -27,7 +27,7 @@
         %button
           %p Edit
     .chat-list
-      =render :partial => 'chat-list', locals: {messages: @messages}
+      =render partial: 'chat-list', locals: {messages: @messages}
     .chat-form
       =form_for [@group, @message] do |f|
         =f.text_field :body, placeholder: "type a message", rows: 1, cols: 30, class: "withicon"


### PR DESCRIPTION
# WHAT

・チャット一覧をビューに表示。
・グループ一覧をリンク化する。
・ヘッダーにグループ名、メンバー名が表示されるようにする。
・編集ボタンからグループ情報編集画面へ遷移するようにする。
・画像付きのメッセージは画像も表示するように記述。
・cssを変更して見た目を整える。

# WHY

・ビューを整えるため。
このプルリクエストでメッセージ送信機能の実装は終了し、テストの学習に移行する。